### PR TITLE
Add dashboard port configuration for reverse proxy support

### DIFF
--- a/luci-app-daed/luasrc/model/cbi/daed/basic.lua
+++ b/luci-app-daed/luasrc/model/cbi/daed/basic.lua
@@ -54,6 +54,11 @@ o.default = 5
 o = s:option(Value, "listen_addr",translate("Set the DAED listen address"))
 o.default = '0.0.0.0:2023'
 
+o = s:option(Value, "dashboard_port", translate("Dashboard Access Port"))
+o.placeholder = translate("Leave empty to use listen port")
+o.datatype = "range(1,65535)"
+o.description = translate("For reverse proxy scenarios, leave empty to use the port from listen address")
+
 m.apply_on_parse = true
 m.on_after_apply = function(self,map)
 	luci.sys.exec("/etc/init.d/daed restart")

--- a/luci-app-daed/luasrc/view/daed/daed.htm
+++ b/luci-app-daed/luasrc/view/daed/daed.htm
@@ -18,12 +18,30 @@
 	}
 	</style>
 	<script type="text/javascript">
-		var listenAddr = "<%=luci.model.uci.cursor():get_first("daed", "daed", "listen_addr")%>";
-		var portRegex = /:(\d+)/;
-		var match = listenAddr.match(portRegex);
-		if (match && match[1]) {
-			var port = match[1];
-			document.getElementById("daed").src = window.location.protocol + "//" + window.location.hostname + ":" + port;
+		var listenAddr = "<%=luci.model.uci.cursor():get_first("daed", "daed", "listen_addr") or ''%>";
+		var dashboardPort = "<%=luci.model.uci.cursor():get_first("daed", "daed", "dashboard_port") or ''%>";
+		
+		var port = "";
+		if (dashboardPort && dashboardPort.trim() !== "") {
+			port = dashboardPort.trim();
+		} else {
+			var portRegex = /:(\d+)/;
+			var match = listenAddr.match(portRegex);
+			if (match && match[1]) {
+				port = match[1];
+			}
+		}
+		
+		if (port) {
+			var protocol = window.location.protocol;
+			var hostname = window.location.hostname;
+			var url = protocol + "//" + hostname;
+			
+			if (!((protocol === "http:" && port === "80") || (protocol === "https:" && port === "443"))) {
+				url += ":" + port;
+			}
+			
+			document.getElementById("daed").src = url;
 		}
 	</script>
 <% else %>

--- a/luci-app-daed/po/zh_Hans/daed.po
+++ b/luci-app-daed/po/zh_Hans/daed.po
@@ -5,7 +5,7 @@ msgid "DAED"
 msgstr "DAED"
 
 msgid "DAE is a Linux high-performance transparent proxy solution based on eBPF, And DAED is a modern dashboard for dae."
-msgstr "DAE是一个基于eBPF的Linux高性能透明代理解决方案，而DAED是DAE的管理面板。"
+msgstr "DAE是一个基于eBPF的Linux高性能透明代理解决方案,而DAED是DAE的管理面板。"
 
 msgid "Base Setting"
 msgstr "基本设置"
@@ -32,10 +32,19 @@ msgid "Logfile retention count"
 msgstr "日志文件保留数量"
 
 msgid "Logfile Max Size (MB)"
-msgstr "日志文件大小（MB）"
+msgstr "日志文件大小(MB)"
 
 msgid "Set the DAED listen address"
 msgstr "设置监听地址"
+
+msgid "Dashboard Access Port"
+msgstr "仪表板访问端口"
+
+msgid "Leave empty to use listen port"
+msgstr "留空则使用监听端口"
+
+msgid "For reverse proxy scenarios, leave empty to use the port from listen address"
+msgstr "用于反向代理场景,留空则使用监听地址的端口"
 
 msgid "DAED is not running"
 msgstr "DAED 未运行"
@@ -50,7 +59,7 @@ msgid "Update Cycle"
 msgstr "更新周期"
 
 msgid "Update Time (Every Day)"
-msgstr "更新时间（每天）"
+msgstr "更新时间(每天)"
 
 msgid "Username"
 msgstr "用户名"


### PR DESCRIPTION
- Add dashboard_port option to allow separate port for web access
- Modify iframe URL construction to prioritize dashboard_port over listen_addr port
- Handle standard ports (80/443) automatically in URL generation
- Add Chinese translations for new configuration option
- Ensure backward compatibility when dashboard_port is not set